### PR TITLE
Fix for extraction of the NMState result for manager.get_state

### DIFF
--- a/src/dbus_nm.rs
+++ b/src/dbus_nm.rs
@@ -54,7 +54,7 @@ impl DBusNetworkManager {
         let response = self.dbus
             .call(NM_SERVICE_PATH, NM_SERVICE_INTERFACE, "state")?;
 
-        let state: i64 = self.dbus.extract(&response)?;
+        let state: u32 = self.dbus.extract(&response)?;
 
         Ok(NetworkManagerState::from(state))
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -134,8 +134,8 @@ pub enum NetworkManagerState {
     ConnectedGlobal,
 }
 
-impl From<i64> for NetworkManagerState {
-    fn from(state: i64) -> Self {
+impl From<u32> for NetworkManagerState {
+    fn from(state: u32) -> Self {
         match state {
             0 => NetworkManagerState::Unknown,
             10 => NetworkManagerState::Asleep,


### PR DESCRIPTION
The manager.get_state() method currently fails with error "Wrong response type".

Looking at the DBUS API, the type for the "state" method return is "u" (uint32):
https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.html

I modified the From<> and manager invocation, and it seems to have fixed the error in my application.