### PR TITLE
Added wifi scan API

### DIFF
--- a/src/dbus_nm.rs
+++ b/src/dbus_nm.rs
@@ -373,6 +373,20 @@ impl DBusNetworkManager {
         Ok(())
     }
 
+    pub fn request_access_point_scan(&self, path: &str) -> Result<()> {
+        let options: VariantMap = HashMap::new();
+        self.dbus.call_with_args(
+            path,
+            NM_WIRELESS_INTERFACE,
+            "RequestScan",
+            &[
+                &options as &RefArg,
+            ],
+        )?;
+
+        Ok(())
+    }
+
     pub fn get_device_access_points(&self, path: &str) -> Result<Vec<String>> {
         self.dbus
             .property(path, NM_WIRELESS_INTERFACE, "AccessPoints")

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -26,6 +26,7 @@ impl<'a> WiFiDevice<'a> {
     /// let devices = manager.get_devices().unwrap();
     /// let i = devices.iter().position(|ref d| *d.device_type() == DeviceType::WiFi).unwrap();
     /// let device = devices[i].as_wifi_device().unwrap();
+    /// device.request_scan()?;
     /// let access_points = device.get_access_points().unwrap();
     /// println!("{:?}", access_points);
     /// ```
@@ -45,6 +46,11 @@ impl<'a> WiFiDevice<'a> {
         access_points.reverse();
 
         Ok(access_points)
+    }
+
+    pub fn request_scan(&self) -> Result<()> {
+        self.dbus_manager.request_access_point_scan( self.device.path())?;
+        Ok(())
     }
 
     pub fn connect<P>(


### PR DESCRIPTION
Just needed the functionality for a project I'm working on. Feel free to modify to your liking. Or not :)

The RequestScan API is not very well documented:
https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Device.Wireless.html#gdbus-method-org-freedesktop-NetworkManager-Device-Wireless.RequestScan

... so I did what everyone else who has written a wrapper for this command and passed in an empty option map.
---- Autogenerated Waffleboard Connection: Connects to #116